### PR TITLE
State managment

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -36,8 +36,12 @@ const mediaArray = [
 ];
 
 import MediaRow from './MediaRow.jsx';
+import {useState} from 'react';
+import SingleView from './SingleView';
 
 const Home = () => {
+  const [selectedItem, setSelectedItem] = useState(null);
+  console.log('selectedItem', selectedItem);
   return (
     <>
       <h2>My Media</h2>
@@ -50,14 +54,18 @@ const Home = () => {
           <th>Created</th>
           <th>Size</th>
           <th>Type</th>
+          <th>Operations</th>
         </tr>
         </thead>
         <tbody>
         {mediaArray.map((item) => (
-         <MediaRow key={item.media_id} item={item} />
+         <MediaRow key={item.media_id}
+                   item={item}
+                   setSelectedItem={setSelectedItem} />
         ))}
         </tbody>
       </table>
+      <SingleView item={selectedItem} setSelectedItem={setSelectedItem} />
     </>
   );
 };

--- a/src/components/MediaRow.jsx
+++ b/src/components/MediaRow.jsx
@@ -1,25 +1,34 @@
 import PropTypes from 'prop-types';
 
 const MediaRow = (props) => {
-  const {item} = props;
+  const {item, setSelectedItem} = props;
+
+  const handleClick = () => {
+    setSelectedItem(item);
+  }
+
   return (
     <>
       <tr>
-      <td>
-        <img src={item.thumbnail} alt={item.title} />
-      </td>
-      <td>{item.title}</td>
-      <td>{item.description}</td>
-      <td>{new Date(item.created_at).toLocaleString('fi-FI')}</td>
-      <td>{item.filesize}</td>
-      <td>{item.media_type}</td>
+        <td>
+          <img src={item.thumbnail} alt={item.title} />
+        </td>
+        <td>{item.title}</td>
+        <td>{item.description}</td>
+        <td>{new Date(item.created_at).toLocaleString('fi-FI')}</td>
+        <td>{item.filesize}</td>
+        <td>{item.media_type}</td>
+        <td>
+          <button onClick={handleClick}>View</button>
+        </td>
       </tr>
     </>
   );
 };
 
 MediaRow.PropTypes = {
-  item: PropTypes.object.isRequired
+  item: PropTypes.object.isRequired,
+  setSelectedItem: PropTypes.func.isRequired
 };
 
 export default MediaRow;

--- a/src/components/SingleView.jsx
+++ b/src/components/SingleView.jsx
@@ -1,0 +1,29 @@
+const SingleView = (props) => {
+  const {item, setSelectedItem} = props;
+
+  const handleClick = () => {
+    setSelectedItem(null);
+  }
+  return (
+    <>
+      {item && (
+        <dialog open>
+          <button onClick={handleClick}>&#10005;</button>
+          {item.media_type.includes('video') ? (
+            <video src={item.filename} controls />
+          ) : (
+            <img src={item.filename} alt={item.title} />
+          )}
+          <h3> Title: {item.title}</h3>
+          <p>{item.description}</p>
+        </dialog>
+      )}
+    </>
+
+  );
+};
+
+export default SingleView;
+
+
+

--- a/src/components/SingleView.jsx
+++ b/src/components/SingleView.jsx
@@ -8,7 +8,7 @@ const SingleView = (props) => {
     <>
       {item && (
         <dialog open>
-          <button onClick={handleClick}>&#10005;</button>
+          <button onClick={handleClick}>&#10005; </button>
           {item.media_type.includes('video') ? (
             <video src={item.filename} controls />
           ) : (


### PR DESCRIPTION
This pull request introduces a new feature to view individual media items in a modal dialog. The changes include the addition of a new component, `SingleView`, and modifications to the `Home` and `MediaRow` components to support this feature.

### New feature: View individual media items

* [`src/components/Home.jsx`](diffhunk://#diff-8bc8933bf9f0a1dece53f0af6a1cf667e51f3286cc1d8aacebe87ff459e2960bR39-R44): Added state management for the selected media item using `useState`, and included the `SingleView` component to display the selected item. [[1]](diffhunk://#diff-8bc8933bf9f0a1dece53f0af6a1cf667e51f3286cc1d8aacebe87ff459e2960bR39-R44) [[2]](diffhunk://#diff-8bc8933bf9f0a1dece53f0af6a1cf667e51f3286cc1d8aacebe87ff459e2960bR57-R68)
* [`src/components/MediaRow.jsx`](diffhunk://#diff-8c58f480258d17d541fab43237fb979efcbf707a21d3031fb10ff62679ee0f3dL4-R9): Modified to accept `setSelectedItem` as a prop and added a button to trigger the selection of a media item. [[1]](diffhunk://#diff-8c58f480258d17d541fab43237fb979efcbf707a21d3031fb10ff62679ee0f3dL4-R9) [[2]](diffhunk://#diff-8c58f480258d17d541fab43237fb979efcbf707a21d3031fb10ff62679ee0f3dR21-R31)
* [`src/components/SingleView.jsx`](diffhunk://#diff-e50be4fd2f1a1afa2795b9ecc7a86eb9f134ff998e1c1aabc1184db624e7d0d0R1-R29): Created a new component to display the details of a selected media item in a modal dialog, with a close button to deselect the item.